### PR TITLE
TailwindCSS v3 Initial Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,28 +11,34 @@ Adapted from [Alfred VueJS Docs](https://github.com/vmitchell85/alfred-vuejs-doc
 
 > **macOS Monterey:** PHP is no longer shipped with macOS, before attempting to use this workflow ensure you have installed the php binary via Homebrew.
 
-1. [Download the latest version](https://github.com/clnt/alfred-tailwindcss-docs/releases/download/v2.0.1/TailwindCSSDocs.alfredworkflow)
+1. [Download the latest version](https://github.com/clnt/alfred-tailwindcss-docs/releases/download/v3.0.0/TailwindCSSDocs.alfredworkflow)
 2. Install the workflow by double-clicking the `.alfredworkflow` file
 3. You can add the workflow to a category, then click "Import" to finish importing. You'll now see the workflow listed in the left sidebar of your Workflows preferences pane.
 
 ## Usage
 
-To search the [v2 docs](https://tailwindcss.com/docs), just type `tw` followed by your search query.
+To search the [v3 docs](https://tailwindcss.com/docs), just type `tw` followed by your search query.
 
 ```
 tw <query>
 ```
 
-To search the [v0 docs](https://v0.tailwindcss.com/docs), just type `tw0` followed by your search query.
+To search the [v2 docs](https://v2.tailwindcss.com/docs), just type `tw2` followed by your search query.
 
 ```
-tw0 <query>
+tw2 <query>
 ```
 
 To search the [v1 docs](https://v1.tailwindcss.com/docs), just type `tw1` followed by your search query.
 
 ```
 tw1 <query>
+```
+
+To search the [v0 docs](https://v0.tailwindcss.com/docs), just type `tw0` followed by your search query.
+
+```
+tw0 <query>
 ```
 
 ![Search by Algolia](algolia.png)

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "clnt/alfred-tailwindcss-docs",
     "description": "An ultra-fast TailwindCSS docs search workflow for Alfred 4.",
-    "version": "2.0.1",
+    "version": "3.0.0",
     "keywords": ["alfred", "alfred-workflow", "tailwindcss", "algolia"],
     "homepage": "https://github.com/clnt",
     "support": {

--- a/info.plist
+++ b/info.plist
@@ -21,6 +21,19 @@
 				<false/>
 			</dict>
 		</array>
+		<key>B6C8B22C-FF5D-43C9-ADD6-A89E98787B42</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>A4601CBF-5351-4B71-8D48-F97FACF4BE7F</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>BA0F1293-0A15-462E-966E-7C84BCFBC501</key>
 		<array>
 			<dict>
@@ -61,25 +74,6 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>browser</key>
-				<string></string>
-				<key>spaces</key>
-				<string></string>
-				<key>url</key>
-				<string>{query}</string>
-				<key>utf8</key>
-				<true/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.openurl</string>
-			<key>uid</key>
-			<string>A0BE7549-BF89-4E85-86DC-E30C0D797564</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
 				<key>alfredfiltersresults</key>
 				<false/>
 				<key>alfredfiltersresultsmatchmode</key>
@@ -117,7 +111,7 @@ fi</string>
 				<key>scriptfile</key>
 				<string></string>
 				<key>subtext</key>
-				<string>Search the TailwindCSS docs...</string>
+				<string>Search the TailwindCSS v3 docs...</string>
 				<key>title</key>
 				<string>TailwindCSS</string>
 				<key>type</key>
@@ -147,7 +141,7 @@ fi</string>
 			<key>type</key>
 			<string>alfred.workflow.action.openurl</string>
 			<key>uid</key>
-			<string>1BC09BF1-F684-4789-897B-F70B225A4D72</string>
+			<string>A0BE7549-BF89-4E85-86DC-E30C0D797564</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -205,6 +199,25 @@ fi</string>
 			<string>89F02255-0DA5-4773-896A-BF05292D2CE8</string>
 			<key>version</key>
 			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>{query}</string>
+				<key>utf8</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>1BC09BF1-F684-4789-897B-F70B225A4D72</string>
+			<key>version</key>
+			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -280,16 +293,96 @@ fi</string>
 			<key>version</key>
 			<integer>3</integer>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>{query}</string>
+				<key>utf8</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>A4601CBF-5351-4B71-8D48-F97FACF4BE7F</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<false/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>0</integer>
+				<key>escaping</key>
+				<integer>127</integer>
+				<key>keyword</key>
+				<string>tw2</string>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<true/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string>Searching docs for "{query}"...</string>
+				<key>script</key>
+				<string>if [ -f "/opt/homebrew/bin/php" ]; then
+    /opt/homebrew/bin/php v2_tailwindcss.php "{query}"
+elif [ -f "/usr/local/bin/php" ]; then
+    /usr/local/bin/php v2_tailwindcss.php "{query}"
+elif [ -f "/usr/bin/php" ]; then
+    /usr/bin/php v2_tailwindcss.php "{query}"
+fi</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string>Search the TailwindCSS v2 docs...</string>
+				<key>title</key>
+				<string>TailwindCSS v2</string>
+				<key>type</key>
+				<integer>0</integer>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>B6C8B22C-FF5D-43C9-ADD6-A89E98787B42</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
 	</array>
 	<key>readme</key>
 	<string>An ultra-fast TailwindCSS docs search workflow for Alfred 3.
 
 ## Usage
 
-To search the [v2 docs](https://tailwindcss.com/docs), just type `tw` followed by your search query.
+To search the [v3 docs](https://tailwindcss.com/docs), just type `tw` followed by your search query.
 
 ```
 tw &lt;query&gt;
+```
+
+To search the [v2 docs](https://v2.tailwindcss.com/docs), just type `tw2` followed by your search query.
+
+```
+tw2 &lt;query&gt;
 ```
 
 To search the [v1 docs](https://v1.tailwindcss.com/docs), just type `tw1` followed by your search query.
@@ -312,21 +405,21 @@ Either press `⌘Y` to Quick Look the result, or press `&lt;enter&gt;` to open i
 			<key>xpos</key>
 			<integer>650</integer>
 			<key>ypos</key>
-			<integer>250</integer>
+			<integer>225</integer>
 		</dict>
 		<key>55F8BC35-9DE7-4CF5-A4B5-C15201065664</key>
 		<dict>
 			<key>xpos</key>
 			<integer>650</integer>
 			<key>ypos</key>
-			<integer>410</integer>
+			<integer>365</integer>
 		</dict>
 		<key>89F02255-0DA5-4773-896A-BF05292D2CE8</key>
 		<dict>
 			<key>xpos</key>
 			<integer>340</integer>
 			<key>ypos</key>
-			<integer>250</integer>
+			<integer>225</integer>
 		</dict>
 		<key>A0BE7549-BF89-4E85-86DC-E30C0D797564</key>
 		<dict>
@@ -334,6 +427,20 @@ Either press `⌘Y` to Quick Look the result, or press `&lt;enter&gt;` to open i
 			<integer>650</integer>
 			<key>ypos</key>
 			<integer>90</integer>
+		</dict>
+		<key>A4601CBF-5351-4B71-8D48-F97FACF4BE7F</key>
+		<dict>
+			<key>xpos</key>
+			<integer>650</integer>
+			<key>ypos</key>
+			<integer>505</integer>
+		</dict>
+		<key>B6C8B22C-FF5D-43C9-ADD6-A89E98787B42</key>
+		<dict>
+			<key>xpos</key>
+			<integer>340</integer>
+			<key>ypos</key>
+			<integer>505</integer>
 		</dict>
 		<key>BA0F1293-0A15-462E-966E-7C84BCFBC501</key>
 		<dict>
@@ -347,13 +454,13 @@ Either press `⌘Y` to Quick Look the result, or press `&lt;enter&gt;` to open i
 			<key>xpos</key>
 			<integer>340</integer>
 			<key>ypos</key>
-			<integer>410</integer>
+			<integer>365</integer>
 		</dict>
 	</dict>
 	<key>variablesdontexport</key>
 	<array/>
 	<key>version</key>
-	<string>2.0.1</string>
+	<string>3.0.0</string>
 	<key>webaddress</key>
 	<string>https://github.com/clnt/alfred-tailwindcss-docs</string>
 </dict>

--- a/tailwindcss.php
+++ b/tailwindcss.php
@@ -13,9 +13,9 @@ $query = $argv[1];
 $workflow = new Workflow;
 $algolia = Algolia::create('R90K1756AM', 'a6e52654d6b591febdf42b07e0e7374a');
 
-AlgoliaUserAgent::addCustomUserAgent('TailwindCSS Alfred Workflow', '2.0.1');
+AlgoliaUserAgent::addCustomUserAgent('TailwindCSS Alfred Workflow', '3.0.0');
 
-$results = getResults($algolia, 'v2_tailwindcss', $query);
+$results = getResults($algolia, 'v3_tailwindcss', $query);
 
 if (empty($results)) {
     $workflow->result()

--- a/v1_tailwindcss.php
+++ b/v1_tailwindcss.php
@@ -13,7 +13,7 @@ $query = $argv[1];
 $workflow = new Workflow;
 $algolia = Algolia::create('R90K1756AM', 'a6e52654d6b591febdf42b07e0e7374a');
 
-AlgoliaUserAgent::addCustomUserAgent('TailwindCSS Alfred Workflow', '2.0.1');
+AlgoliaUserAgent::addCustomUserAgent('TailwindCSS Alfred Workflow', '3.0.0');
 
 $results = getResults($algolia, 'tailwindcss', $query);
 

--- a/v2_tailwindcss.php
+++ b/v2_tailwindcss.php
@@ -15,7 +15,7 @@ $algolia = Algolia::create('R90K1756AM', 'a6e52654d6b591febdf42b07e0e7374a');
 
 AlgoliaUserAgent::addCustomUserAgent('TailwindCSS Alfred Workflow', '3.0.0');
 
-$results = getResults($algolia, 'v0_tailwindcss', $query);
+$results = getResults($algolia, 'v2_tailwindcss', $query);
 
 if (empty($results)) {
     $workflow->result()


### PR DESCRIPTION
- Workflow updated to move TailwindCSS v2 docs search to the `tw2` command, v3 docs now searched using `tw` command.
- Initial v3 Algolia search index built using a custom docsearch configuration, needs more modifications to fix some missing entries and errors currently being generated by the scraper. I will post my current index config in open issue if anyone can lend a hand would be much appreciated! #12 (Current v3 index has ~300 entries unlike the 10k entries in the v2 index)